### PR TITLE
Add expanded roles and personas to project management documentation

### DIFF
--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -75,7 +75,104 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
+## Scrum Master
+
+### Role Summary
+Scrum Masters facilitate Agile ceremonies, remove blockers, and foster team self-organization. They serve as process guardians and coaches for continuous improvement.
+
+### Responsibilities
+- Facilitate standups, sprint planning, reviews, and retrospectives
+- Coach teams in Agile best practices and methodologies
+- Identify and resolve team impediments and blockers
+- Serve as process guardian and advocate for continual improvement
+- Protect the team from scope creep and external disruptions
+
+### Goals
+- Enable high-performing, self-organizing teams
+- Maximize delivery velocity and team morale
+- Reduce cycle time and improve process efficiency
+
+### Typical Communication
+- Daily standups and sprint ceremonies
+- One-on-ones with team members
+- Retrospective action items and process improvements
+
+---
+
+## UX Designer
+
+### Role Summary
+UX Designers champion user experience and translate requirements into intuitive, accessible designs. They ensure products meet user needs and are easy to use.
+
+### Responsibilities
+- Conduct user research and usability studies
+- Create wireframes, mockups, and interactive prototypes
+- Collaborate on acceptance criteria for user experience
+- Advocate for accessibility and inclusive design
+- Validate design decisions through user testing
+
+### Goals
+- Deliver intuitive, user-centered solutions
+- Maximize user satisfaction and adoption
+- Ensure accessibility and inclusive design practices
+
+### Typical Communication
+- Design review sessions with product and engineering
+- Usability testing findings and recommendations
+- Design specifications and hand-offs to development
+
+---
+
+## Release Manager
+
+### Role Summary
+Release Managers oversee release planning, communication, and risk management. They coordinate cutover activities and ensure reliable, safe deployments.
+
+### Responsibilities
+- Maintain release calendar and deployment schedules
+- Coordinate deployment and rollback plans
+- Communicate release details and changes to stakeholders
+- Validate release readiness with QA and development teams
+- Monitor post-deployment health and support incident response
+
+### Goals
+- Ensure timely, reliable releases with minimal risk
+- Maintain clear stakeholder communication on release status
+- Enable rapid rollback and incident recovery if needed
+
+### Typical Communication
+- Release planning and coordination meetings
+- Stakeholder release notes and status updates
+- Deployment checklists and post-deployment reviews
+
+---
+
+## Business Analyst
+
+### Role Summary
+Business Analysts translate business requirements into clear user stories and technical specifications. They bridge business stakeholders and delivery teams.
+
+### Responsibilities
+- Elicit and document business and user requirements
+- Define acceptance criteria with Product Manager and stakeholders
+- Map requirements to technical solutions and features
+- Identify gaps, risks, and process improvement opportunities
+- Trace requirements through design, development, and testing
+
+### Goals
+- Ensure accurate requirements translation and alignment
+- Reduce rework and scope ambiguity
+- Improve traceability and stakeholder satisfaction
+
+### Typical Communication
+- Requirements documentation and user stories
+- Stakeholder interviews and clarification sessions
+- Acceptance criteria and test case reviews
+
+---
+
 ## How these personas are used in the exercise
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
+- When assigning work or facilitating cross-functional discussions, refer to these persona descriptions to understand responsibilities and communication preferences.
 


### PR DESCRIPTION
## Description

This pull request expands the roles and personas documentation to include additional roles that promote clarity and accountability in the project management process.

### Changes
- **Scrum Master**: Facilitates Agile ceremonies, removes blockers, and fosters team self-organization
- **UX Designer**: Champions user experience and translates requirements into intuitive designs
- **Release Manager**: Oversees release planning, communication, and risk management
- **Business Analyst**: Translates business requirements into clear user stories and technical specs

### Why These Changes?
The current documentation focuses on core PM, PdM, Developer, and Stakeholder personas. As project complexity grows, additional contributor roles are increasingly involved. Explicitly outlining these personas will:
- Improve onboarding for diverse team members
- Clarify cross-role accountability and hand-offs
- Reduce ambiguity in deliverables and decision-making
- Align documentation with real-world practices and stakeholder feedback

Closes #4